### PR TITLE
add new musk v2 dataset

### DIFF
--- a/python/NEWS.md
+++ b/python/NEWS.md
@@ -1,6 +1,7 @@
 # `tabben` v0.0.5
 
 ## New Features
+- new dataset: [musk (version 2)](https://archive.ics.uci.edu/ml/datasets/Musk+(Version+2))
 
 ## Breaking Changes
 

--- a/python/src/tabben/datasets/data.toml
+++ b/python/src/tabben/datasets/data.toml
@@ -38,3 +38,8 @@ task = "classification"
 data_location = "https://github.com/umd-otb/OpenTabularDataBenchmark/releases/download/v0.0.4-pre/parkinsons.npz"
 outputs = 2
 task = "regression"
+
+[musk]
+data_location = "https://github.com/umd-otb/OpenTabularDataBenchmark/releases/download/v0.0.5-pre/musk.npz"
+task = "classification"
+classes = 2

--- a/python/tests/test_datasets.py
+++ b/python/tests/test_datasets.py
@@ -96,6 +96,23 @@ def test_covertype(tmp_path):
 
 # test for higgs not included here because of its large size
 
+def test_musk(tmp_path):
+    num_features = 166
+    train_examples = 5278
+    test_examples = 1320
+    
+    check_split_sizes(tmp_path, 'musk', {
+        'train': (train_examples, num_features),
+        'test': (test_examples, num_features),
+    }, )
+    
+    check_attributes(tmp_path, 'musk', {
+        'task'       : 'classification',
+        'num_outputs': 1,
+        'num_classes': 2,
+    })
+
+
 def test_parkinsons(tmp_path):
     num_features = 16
     num_outputs = 2

--- a/scripts/musk.py
+++ b/scripts/musk.py
@@ -1,0 +1,53 @@
+import os
+
+import pandas as pd
+import simplejson as json
+
+from utils import save_to_numpy_array, create_csv_reader, default_arg_parser, column_name_array, \
+    split_by_label
+
+column_names = [
+    'molecule_name',  # NOT used as input
+    'conformation_name',  # NOT used as input
+    *[f'f{num}' for num in range(1, 166+1)],
+    'musk',
+]
+
+
+def convert_format(config):
+    read_csv = create_csv_reader(
+            config.source,
+            header=None,
+            index_col=None,
+            names=column_names,
+            usecols=column_names[2:],
+            sep=',',
+    )
+    
+    df = read_csv('clean2.data')
+    
+    df = df.sample(frac=1, random_state=171_234)
+    train_examples = int(0.80 * df.shape[0])
+    
+    train_df = df.iloc[:train_examples]
+    test_df = df.iloc[train_examples:]
+    train_data_df, train_labels_df = split_by_label(train_df, 'musk')
+    test_data_df, test_labels_df = split_by_label(test_df, 'musk')
+    print(df.shape, train_df.shape, test_df.shape)
+    save_to_numpy_array(os.path.join(config.outputdirectory, 'musk'), {
+        'train-data'     : train_data_df,
+        'train-labels'   : train_labels_df,
+        'test-data'      : test_data_df,
+        'test-labels'    : test_labels_df,
+        '_columns-data'  : column_name_array(train_data_df),
+        '_columns-labels': column_name_array(train_labels_df),
+    })
+
+
+if __name__ == '__main__':
+    args = default_arg_parser(
+            source_default='https://archive.ics.uci.edu/ml/machine-learning-databases/musk/',
+    ).parse_args()
+    
+    convert_format(args)
+


### PR DESCRIPTION
Support for the classification dataset [musk (version 2)](https://archive.ics.uci.edu/ml/datasets/Musk+(Version+2)) (not in the list in #1).